### PR TITLE
feat: extend admin_index TenantConfigSection (Phase 5 slice)

### DIFF
--- a/apps/tplanet-AI/src/pages/backend/PageManage/AdminIndex.jsx
+++ b/apps/tplanet-AI/src/pages/backend/PageManage/AdminIndex.jsx
@@ -185,30 +185,35 @@ const HomepageEditor = () => {
   const saveTenantConfig = async () => {
     try {
       let configToSave = { ...tenantConfig };
+      const jwt = localStorage.getItem("jwt") || "";
 
       if (kpiBannerFile) {
         const form = new FormData();
-        form.append("email", localStorage.getItem("email"));
+        // email is ignored by backend (derived from JWT), kept for parity
+        form.append("email", localStorage.getItem("email") || "");
         form.append("kpi-banner", kpiBannerFile, kpiBannerFile.name);
         const uploadResp = await fetch(
           `${import.meta.env.VITE_HOST_URL_TPLANET}/api/mockup/new`,
-          { method: "POST", body: form }
+          {
+            method: "POST",
+            body: form,
+            headers: jwt ? { Authorization: `Bearer ${jwt}` } : {},
+          }
         );
         if (!uploadResp.ok) {
-          throw new Error("KPI banner upload failed");
+          alert(t("edit.cms_save_failed"));
+          return false;
         }
         const uploadObj = await uploadResp.json();
-        // Trust backend for the real URL (handles extension correctly).
         const uploadedUrl = uploadObj?.description?.["kpi-banner"];
         if (uploadedUrl) {
           configToSave = { ...configToSave, kpiBannerUrl: uploadedUrl };
-          setTenantConfig(configToSave);
-          setKpiBannerFile(null);
-          setKpiBannerPreview("");
         }
+        // Note: we do NOT clear kpiBannerFile / preview here yet — only after
+        // the subsequent PUT succeeds, otherwise a failed PUT would lose the
+        // user's selection.
       }
 
-      const jwt = localStorage.getItem("jwt") || "";
       const response = await fetch(
         `${import.meta.env.VITE_HOST_URL_TPLANET}/api/tenant/admin-config`,
         {
@@ -221,6 +226,9 @@ const HomepageEditor = () => {
         }
       );
       if (response.ok) {
+        setTenantConfig(configToSave);
+        setKpiBannerFile(null);
+        setKpiBannerPreview("");
         setTenantConfigDirty(false);
         return true;
       }
@@ -341,11 +349,13 @@ const HomepageEditor = () => {
         }
       });
 
+      const mockupJwt = localStorage.getItem("jwt") || "";
       const response = await fetch(
         `${import.meta.env.VITE_HOST_URL_TPLANET}/api/mockup/new`,
         {
           method: "POST",
           body: form,
+          headers: mockupJwt ? { Authorization: `Bearer ${mockupJwt}` } : {},
         }
       );
 

--- a/apps/tplanet-AI/src/pages/backend/PageManage/AdminIndex.jsx
+++ b/apps/tplanet-AI/src/pages/backend/PageManage/AdminIndex.jsx
@@ -20,6 +20,11 @@ const HomepageEditor = () => {
   });
   const [tenantConfigDirty, setTenantConfigDirty] = useState(false);
 
+  // KPI banner upload state (handled separately since the file posts to mockup
+  // endpoint before the tenant-config PUT)
+  const [kpiBannerFile, setKpiBannerFile] = useState(null);
+  const [kpiBannerPreview, setKpiBannerPreview] = useState("");
+
   // 新增：實際要上傳的檔案
   const [files, setFiles] = useState({});
   const [errors, setErrors] = useState({});
@@ -145,9 +150,64 @@ const HomepageEditor = () => {
     setTenantConfigDirty(true);
   };
 
+  // KPI banner file selection (validation + preview only; actual upload in handleSave)
+  const handleKpiBannerSelect = (file) => {
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    const allowedTypes = ["image/jpeg", "image/png", "image/jpg", "image/gif", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      alert(t("edit.cms_upload_format"));
+      return;
+    }
+    if (file.size > maxSize) {
+      alert(t("edit.cms_upload_size"));
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => setKpiBannerPreview(e.target.result);
+    reader.readAsDataURL(file);
+    setKpiBannerFile(file);
+    setTenantConfigDirty(true);
+  };
+
+  const clearKpiBannerSelection = () => {
+    setKpiBannerFile(null);
+    setKpiBannerPreview("");
+  };
+
   // Save tenant config
+  //
+  // Flow:
+  //   1. If admin chose a new KPI banner file, POST it to /api/mockup/new first.
+  //      Backend stores the file under /static/new_mockup/<email>/kpi-banner.<ext>
+  //      and returns the real URL (with correct extension).
+  //   2. PUT the tenant config (including the newly returned kpiBannerUrl) to
+  //      /api/tenant/admin-config.
   const saveTenantConfig = async () => {
     try {
+      let configToSave = { ...tenantConfig };
+
+      if (kpiBannerFile) {
+        const form = new FormData();
+        form.append("email", localStorage.getItem("email"));
+        form.append("kpi-banner", kpiBannerFile, kpiBannerFile.name);
+        const uploadResp = await fetch(
+          `${import.meta.env.VITE_HOST_URL_TPLANET}/api/mockup/new`,
+          { method: "POST", body: form }
+        );
+        if (!uploadResp.ok) {
+          throw new Error("KPI banner upload failed");
+        }
+        const uploadObj = await uploadResp.json();
+        // Trust backend for the real URL (handles extension correctly).
+        const uploadedUrl = uploadObj?.description?.["kpi-banner"];
+        if (uploadedUrl) {
+          configToSave = { ...configToSave, kpiBannerUrl: uploadedUrl };
+          setTenantConfig(configToSave);
+          setKpiBannerFile(null);
+          setKpiBannerPreview("");
+        }
+      }
+
       const jwt = localStorage.getItem("jwt") || "";
       const response = await fetch(
         `${import.meta.env.VITE_HOST_URL_TPLANET}/api/tenant/admin-config`,
@@ -157,7 +217,7 @@ const HomepageEditor = () => {
             "Content-Type": "application/json",
             ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
           },
-          body: JSON.stringify(tenantConfig),
+          body: JSON.stringify(configToSave),
         }
       );
       if (response.ok) {
@@ -551,21 +611,87 @@ const HomepageEditor = () => {
               />
             </div>
 
-            {/* KPI banner URL (Slice 3 會補上傳 UI；先留 text 讓 admin 可直接填) */}
+            {/* KPI banner: preview + upload or URL */}
             <div className="md:col-span-2">
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                KPI 頁 Banner URL
+                KPI 頁 Banner
                 <span className="ml-1 text-xs text-gray-400">
-                  (留空則使用預設 banner)
+                  (留空則使用預設 banner；建議 2400×400，6:1)
                 </span>
               </label>
-              <input
-                type="text"
-                value={tenantConfig.kpiBannerUrl}
-                onChange={(e) => updateTenantConfig("kpiBannerUrl", e.target.value)}
-                placeholder="/static/new_mockup/.../kpi-banner.png"
-                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
+              <div className="flex flex-col md:flex-row gap-4 items-start">
+                <div className="flex-shrink-0 w-full md:w-56 h-20 bg-gray-100 rounded border border-gray-200 overflow-hidden flex items-center justify-center">
+                  {kpiBannerPreview ? (
+                    <img
+                      src={kpiBannerPreview}
+                      alt="KPI banner preview"
+                      className="object-contain h-full w-full"
+                    />
+                  ) : tenantConfig.kpiBannerUrl ? (
+                    <img
+                      src={
+                        tenantConfig.kpiBannerUrl.startsWith("http")
+                          ? tenantConfig.kpiBannerUrl
+                          : `${import.meta.env.VITE_HOST_URL_TPLANET}${tenantConfig.kpiBannerUrl}`
+                      }
+                      alt="KPI banner"
+                      className="object-contain h-full w-full"
+                      onError={(e) => {
+                        e.currentTarget.style.display = "none";
+                      }}
+                    />
+                  ) : (
+                    <span className="text-xs text-gray-400">尚未設定</span>
+                  )}
+                </div>
+                <div className="flex-1 w-full">
+                  <input
+                    type="text"
+                    value={tenantConfig.kpiBannerUrl}
+                    onChange={(e) => updateTenantConfig("kpiBannerUrl", e.target.value)}
+                    placeholder="/static/new_mockup/.../kpi-banner.png"
+                    className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  />
+                  <div className="mt-2 flex gap-2 items-center">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        document.getElementById("kpi-banner-upload").click()
+                      }
+                      className="bg-[#317EE0] text-white px-4 py-2 rounded hover:bg-blue-600 text-sm"
+                    >
+                      選擇圖片上傳
+                    </button>
+                    {kpiBannerFile && (
+                      <>
+                        <span className="text-xs text-gray-500 truncate max-w-[180px]">
+                          {kpiBannerFile.name}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={clearKpiBannerSelection}
+                          className="text-sm text-gray-500 hover:text-gray-700"
+                        >
+                          取消選擇
+                        </button>
+                      </>
+                    )}
+                    <input
+                      id="kpi-banner-upload"
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={(e) =>
+                        e.target.files[0] &&
+                        handleKpiBannerSelect(e.target.files[0])
+                      }
+                    />
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500">
+                    儲存後上傳並自動更新 URL（副檔名以實際檔案為準）。
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/tplanet-AI/src/pages/backend/PageManage/AdminIndex.jsx
+++ b/apps/tplanet-AI/src/pages/backend/PageManage/AdminIndex.jsx
@@ -10,9 +10,13 @@ const HomepageEditor = () => {
   // Tenant config state
   const [tenantConfig, setTenantConfig] = useState({
     name: "",
+    brandName: "",
     primaryColor: "#1976d2",
     secondaryColor: "#424242",
     logoUrl: "",
+    kpiBannerUrl: "",
+    socialLinks: { facebook: "", youtube: "" },
+    privacyUrl: "",
   });
   const [tenantConfigDirty, setTenantConfigDirty] = useState(false);
 
@@ -58,17 +62,31 @@ const HomepageEditor = () => {
   useEffect(() => {
     const loadTenantConfig = async () => {
       try {
+        const jwt = localStorage.getItem("jwt") || "";
         const response = await fetch(
           `${import.meta.env.VITE_HOST_URL_TPLANET}/api/tenant/admin-config`,
-          { headers: { Accept: "application/json" } }
+          {
+            headers: {
+              Accept: "application/json",
+              ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+            },
+          }
         );
         if (response.ok) {
           const config = await response.json();
           setTenantConfig({
             name: config.name || "",
+            brandName: config.brandName || "",
             primaryColor: config.primaryColor || "#1976d2",
             secondaryColor: config.secondaryColor || "#424242",
             logoUrl: config.logoUrl || "",
+            kpiBannerUrl: config.kpiBannerUrl || "",
+            socialLinks: {
+              facebook: config.socialLinks?.facebook || "",
+              youtube: config.socialLinks?.youtube || "",
+              ...(config.socialLinks || {}),
+            },
+            privacyUrl: config.privacyUrl || "",
           });
         }
       } catch (e) {
@@ -112,20 +130,33 @@ const HomepageEditor = () => {
     mockup_get();
   }, []);
 
-  // Update tenant config field
+  // Update tenant config field (flat key)
   const updateTenantConfig = (key, value) => {
     setTenantConfig((prev) => ({ ...prev, [key]: value }));
+    setTenantConfigDirty(true);
+  };
+
+  // Update nested socialLinks entry (facebook / youtube / ...)
+  const updateSocialLink = (platform, value) => {
+    setTenantConfig((prev) => ({
+      ...prev,
+      socialLinks: { ...(prev.socialLinks || {}), [platform]: value },
+    }));
     setTenantConfigDirty(true);
   };
 
   // Save tenant config
   const saveTenantConfig = async () => {
     try {
+      const jwt = localStorage.getItem("jwt") || "";
       const response = await fetch(
         `${import.meta.env.VITE_HOST_URL_TPLANET}/api/tenant/admin-config`,
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+          },
           body: JSON.stringify(tenantConfig),
         }
       );
@@ -454,6 +485,88 @@ const HomepageEditor = () => {
               style={{ backgroundColor: tenantConfig.secondaryColor }}
             />
             <span className="text-sm">輔助色</span>
+          </div>
+        </div>
+
+        {/* 品牌 / 社群 / 隱私 / KPI banner */}
+        <div className="mt-6 pt-6 border-t border-gray-200">
+          <h3 className="text-lg font-semibold mb-4">品牌 / 社群 / 隱私</h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* 品牌名稱 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                品牌名稱
+                <span className="ml-1 text-xs text-gray-400">
+                  (footer 顯示，留空則沿用站台名稱)
+                </span>
+              </label>
+              <input
+                type="text"
+                value={tenantConfig.brandName}
+                onChange={(e) => updateTenantConfig("brandName", e.target.value)}
+                placeholder="Second Home"
+                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+
+            {/* 隱私權政策 URL */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                隱私權政策 URL
+              </label>
+              <input
+                type="text"
+                value={tenantConfig.privacyUrl}
+                onChange={(e) => updateTenantConfig("privacyUrl", e.target.value)}
+                placeholder="https://privacy.example.com/"
+                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+
+            {/* Facebook */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Facebook URL
+              </label>
+              <input
+                type="text"
+                value={tenantConfig.socialLinks?.facebook || ""}
+                onChange={(e) => updateSocialLink("facebook", e.target.value)}
+                placeholder="https://www.facebook.com/..."
+                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+
+            {/* YouTube */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                YouTube URL
+              </label>
+              <input
+                type="text"
+                value={tenantConfig.socialLinks?.youtube || ""}
+                onChange={(e) => updateSocialLink("youtube", e.target.value)}
+                placeholder="https://www.youtube.com/..."
+                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+
+            {/* KPI banner URL (Slice 3 會補上傳 UI；先留 text 讓 admin 可直接填) */}
+            <div className="md:col-span-2">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                KPI 頁 Banner URL
+                <span className="ml-1 text-xs text-gray-400">
+                  (留空則使用預設 banner)
+                </span>
+              </label>
+              <input
+                type="text"
+                value={tenantConfig.kpiBannerUrl}
+                onChange={(e) => updateTenantConfig("kpiBannerUrl", e.target.value)}
+                placeholder="/static/new_mockup/.../kpi-banner.png"
+                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/tplanet-AI/src/utils/Mockup.jsx
+++ b/apps/tplanet-AI/src/utils/Mockup.jsx
@@ -1,11 +1,18 @@
 // 上傳 mockup
+//
+// Note: /api/mockup/new is auth-gated server-side (Bearer JWT required; caller
+// must be tenant hosters[0] or a YAML superuser). The `email` POST field is
+// ignored by the backend — it derives the email from the JWT user to prevent
+// impersonation.
 export async function mockup_upload(form) {
   try {
+    const jwt = (typeof localStorage !== "undefined" && localStorage.getItem("jwt")) || "";
     const response = await fetch(
       `${import.meta.env.VITE_HOST_URL_TPLANET}/api/mockup/new`,
       {
         method: "POST",
         body: form,
+        headers: jwt ? { Authorization: `Bearer ${jwt}` } : {},
       }
     );
 

--- a/apps/tplanet-daemon/backend/django_multi_tenant/migrations/0003_add_content_fields.py
+++ b/apps/tplanet-daemon/backend/django_multi_tenant/migrations/0003_add_content_fields.py
@@ -1,0 +1,62 @@
+"""
+Migration to add content-type fields to TenantConfig.
+
+Adds fields previously only editable via tenants.yml so admins can
+maintain them through the CMS:
+
+- brand_name        : footer / copyright brand (falls back to name when empty)
+- kpi_banner_url    : /kpi page banner image URL
+- social_links      : {facebook, youtube, ...}
+- privacy_url       : privacy policy URL
+
+Refs: town-intelligent/tplanet-multi-tenant#64
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("django_multi_tenant", "0002_add_hosters"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tenantconfig",
+            name="brand_name",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=200,
+                help_text="Footer / copyright brand name (falls back to name when empty)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="tenantconfig",
+            name="kpi_banner_url",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="URL or path to KPI page banner image",
+            ),
+        ),
+        migrations.AddField(
+            model_name="tenantconfig",
+            name="social_links",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Social media links (JSON object, e.g. {facebook, youtube})",
+            ),
+        ),
+        migrations.AddField(
+            model_name="tenantconfig",
+            name="privacy_url",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="Privacy policy URL shown in footer",
+            ),
+        ),
+    ]

--- a/apps/tplanet-daemon/backend/django_multi_tenant/models.py
+++ b/apps/tplanet-daemon/backend/django_multi_tenant/models.py
@@ -1,0 +1,164 @@
+"""
+TenantConfig model for database-stored tenant configuration.
+
+Provides editable tenant settings that override YAML defaults.
+"""
+
+from django.db import models
+
+
+class TenantConfig(models.Model):
+    """
+    Database-stored tenant configuration.
+
+    Overrides YAML configuration when values are set.
+    Domain/database settings remain in YAML (infrastructure config).
+    """
+
+    tenant_id = models.CharField(
+        max_length=50,
+        unique=True,
+        db_index=True,
+        help_text="Unique tenant identifier (matches YAML tenant key)",
+    )
+    name = models.CharField(
+        max_length=200,
+        help_text="Display name for the tenant",
+    )
+    brand_name = models.CharField(
+        max_length=200,
+        blank=True,
+        default="",
+        help_text="Footer / copyright brand name (falls back to name when empty)",
+    )
+
+    # Theme
+    logo_url = models.TextField(
+        blank=True,
+        null=True,
+        help_text="URL or path to tenant logo",
+    )
+    primary_color = models.CharField(
+        max_length=7,
+        default="#1976d2",
+        help_text="Primary theme color (hex format)",
+    )
+    secondary_color = models.CharField(
+        max_length=7,
+        default="#424242",
+        help_text="Secondary theme color (hex format)",
+    )
+
+    # Content
+    banner_image = models.TextField(
+        blank=True,
+        null=True,
+        help_text="URL or path to banner image",
+    )
+    section_images = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Section-specific images (JSON object)",
+    )
+    section_descriptions = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Section-specific descriptions (JSON object)",
+    )
+    kpi_banner_url = models.TextField(
+        blank=True,
+        default="",
+        help_text="URL or path to KPI page banner image",
+    )
+    social_links = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Social media links (JSON object, e.g. {facebook, youtube})",
+    )
+    privacy_url = models.TextField(
+        blank=True,
+        default="",
+        help_text="Privacy policy URL shown in footer",
+    )
+
+    # Settings
+    features = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Feature flags (JSON object)",
+    )
+    departments = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Department list (JSON array)",
+    )
+    settings = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Additional settings (JSON object)",
+    )
+    hosters = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Site hosters list (JSON array). hosters[0]=admin, hosters[1:]=members",
+    )
+
+    # Metadata
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    is_active = models.BooleanField(
+        default=True,
+        db_index=True,
+        help_text="Whether this config is active",
+    )
+
+    class Meta:
+        db_table = "tenant_config"
+        verbose_name = "Tenant Configuration"
+        verbose_name_plural = "Tenant Configurations"
+        ordering = ["tenant_id"]
+
+    def __str__(self):
+        return f"{self.name} ({self.tenant_id})"
+
+    def to_dict(self):
+        """Convert to dictionary for API responses."""
+        return {
+            "tenantId": self.tenant_id,
+            "name": self.name,
+            "brandName": self.brand_name or "",
+            "logoUrl": self.logo_url,
+            "primaryColor": self.primary_color,
+            "secondaryColor": self.secondary_color,
+            "bannerImage": self.banner_image,
+            "sectionImages": self.section_images or {},
+            "sectionDescriptions": self.section_descriptions or {},
+            "kpiBannerUrl": self.kpi_banner_url or "",
+            "socialLinks": self.social_links or {},
+            "privacyUrl": self.privacy_url or "",
+            "features": self.features or {},
+            "departments": self.departments or [],
+            "settings": self.settings or {},
+            "hosters": self.hosters or [],
+            "isActive": self.is_active,
+            "updatedAt": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    @classmethod
+    def from_yaml_config(cls, tenant_id: str, yaml_config: dict) -> "TenantConfig":
+        """Create a TenantConfig instance from YAML config (for sync)."""
+        theme = yaml_config.get("theme", {})
+        return cls(
+            tenant_id=tenant_id,
+            name=yaml_config.get("name", tenant_id),
+            brand_name=yaml_config.get("brand_name", "") or "",
+            logo_url=theme.get("logo_url"),
+            primary_color=theme.get("primary_color", "#1976d2"),
+            secondary_color=theme.get("secondary_color", "#424242"),
+            kpi_banner_url=yaml_config.get("kpi_banner_url", "") or "",
+            social_links=yaml_config.get("social_links", {}) or {},
+            privacy_url=yaml_config.get("privacy_url", "") or "",
+            features=yaml_config.get("features", {}),
+            departments=yaml_config.get("departments", []),
+            settings=yaml_config.get("settings", {}),
+        )

--- a/apps/tplanet-daemon/backend/django_multi_tenant/views.py
+++ b/apps/tplanet-daemon/backend/django_multi_tenant/views.py
@@ -9,6 +9,9 @@ import re
 from pathlib import Path
 from typing import Any
 
+import jwt as _jwt
+from django.conf import settings as _settings
+from django.contrib.auth.models import User
 from django.http import HttpRequest, JsonResponse
 from django.views.decorators.http import require_GET, require_http_methods
 from django.views.decorators.csrf import csrf_exempt
@@ -19,6 +22,69 @@ logger = logging.getLogger(__name__)
 
 # Validation patterns
 HEX_COLOR_PATTERN = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+
+def _extract_bearer_token(request: HttpRequest) -> str | None:
+    """Extract JWT from Authorization header or JSON body {token}."""
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[7:].strip() or None
+    try:
+        if request.content_type and "json" in request.content_type:
+            data = json.loads(request.body or b"{}")
+            return data.get("token") or data.get("jwt")
+    except Exception:
+        pass
+    return None
+
+
+def _require_tenant_admin(request: HttpRequest):
+    """
+    Verify caller is admin/superuser of the current tenant.
+
+    Returns (email, None) on success; (None, JsonResponse) on failure.
+    Admin = tenant's hosters[0]. Superuser = tenant YAML's superusers list.
+    """
+    token = _extract_bearer_token(request)
+    if not token:
+        return None, JsonResponse({"error": "Authentication required"}, status=401)
+
+    try:
+        payload = _jwt.decode(token, _settings.SECRET_KEY, algorithms=["HS256"])
+    except _jwt.ExpiredSignatureError:
+        return None, JsonResponse({"error": "Token expired"}, status=401)
+    except _jwt.InvalidTokenError:
+        return None, JsonResponse({"error": "Invalid token"}, status=401)
+
+    user_id = payload.get("user_id")
+    if not user_id:
+        return None, JsonResponse({"error": "Invalid token payload"}, status=401)
+
+    user = User.objects.filter(id=user_id).first()
+    if not user:
+        return None, JsonResponse({"error": "Token user not found"}, status=401)
+    email = user.email
+
+    tenant = get_current_tenant()
+    if not tenant:
+        return None, JsonResponse({"error": "No tenant context"}, status=400)
+
+    superusers = tenant.config.get("superusers", []) or []
+    if email in superusers:
+        return email, None
+
+    from django_multi_tenant.models import TenantConfig
+    db_config = TenantConfig.objects.filter(tenant_id=tenant.tenant_id).first()
+    hosters = (
+        db_config.hosters if db_config and db_config.hosters
+        else tenant.config.get("hosters", [])
+    ) or []
+    if hosters and hosters[0] == email:
+        return email, None
+
+    return None, JsonResponse(
+        {"error": "Admin/superuser access required"}, status=403
+    )
 
 
 def _validate_hex_color(value: str) -> bool:
@@ -85,7 +151,10 @@ def tenant_config(request):
         "tenantId": tenant.tenant_id,
         "name": db_config.name if db_config else tenant.name,
         "logoUrl": db_config.logo_url if db_config and db_config.logo_url else tenant.config.get("theme", {}).get("logo_url", ""),
-        "brandName": tenant.config.get("brand_name", tenant.name),
+        "brandName": (
+            db_config.brand_name if db_config and db_config.brand_name
+            else tenant.config.get("brand_name", tenant.name)
+        ),
         "features": db_config.features if db_config and db_config.features else tenant.config.get("features", {}),
         "theme": {
             **tenant.config.get("theme", {}),
@@ -98,9 +167,18 @@ def tenant_config(request):
         "superusers": tenant.config.get("superusers", []),
         "districts": tenant.config.get("districts", []),
         "regions": tenant.config.get("regions", {}),
-        "socialLinks": tenant.config.get("social_links", {}),
-        "privacyUrl": tenant.config.get("privacy_url", ""),
-        "kpiBannerUrl": tenant.config.get("kpi_banner_url", ""),
+        "socialLinks": (
+            db_config.social_links if db_config and db_config.social_links
+            else tenant.config.get("social_links", {})
+        ),
+        "privacyUrl": (
+            db_config.privacy_url if db_config and db_config.privacy_url
+            else tenant.config.get("privacy_url", "")
+        ),
+        "kpiBannerUrl": (
+            db_config.kpi_banner_url if db_config and db_config.kpi_banner_url
+            else tenant.config.get("kpi_banner_url", "")
+        ),
     })
 
 
@@ -112,10 +190,15 @@ def admin_config(request: HttpRequest) -> JsonResponse:
 
     GET: Returns current editable configuration
     PUT: Updates tenant configuration in database
+
+    Auth: Bearer JWT from hosters[0] (tenant admin) or YAML superusers list.
     """
+    email, auth_error = _require_tenant_admin(request)
+    if auth_error:
+        return auth_error
+
     tenant = get_current_tenant()
-    if not tenant:
-        return JsonResponse({"error": "No tenant context"}, status=400)
+    # _require_tenant_admin already verified tenant exists
 
     from django_multi_tenant.models import TenantConfig
 
@@ -127,6 +210,10 @@ def admin_config(request: HttpRequest) -> JsonResponse:
         return JsonResponse({
             "tenantId": tenant.tenant_id,
             "name": db_config.name if db_config else tenant.name,
+            "brandName": (
+                db_config.brand_name if db_config and db_config.brand_name
+                else yaml_config.get("brand_name", "")
+            ),
             "primaryColor": (
                 db_config.primary_color
                 if db_config
@@ -145,6 +232,18 @@ def admin_config(request: HttpRequest) -> JsonResponse:
             "bannerImage": db_config.banner_image if db_config else None,
             "sectionImages": db_config.section_images if db_config else {},
             "sectionDescriptions": db_config.section_descriptions if db_config else {},
+            "kpiBannerUrl": (
+                db_config.kpi_banner_url if db_config and db_config.kpi_banner_url
+                else yaml_config.get("kpi_banner_url", "")
+            ),
+            "socialLinks": (
+                db_config.social_links if db_config and db_config.social_links
+                else yaml_config.get("social_links", {})
+            ),
+            "privacyUrl": (
+                db_config.privacy_url if db_config and db_config.privacy_url
+                else yaml_config.get("privacy_url", "")
+            ),
             "features": (
                 db_config.features
                 if db_config and db_config.features
@@ -192,6 +291,17 @@ def admin_config(request: HttpRequest) -> JsonResponse:
             if not _validate_url(data["bannerImage"]):
                 errors.append("bannerImage must be a relative path or valid URL")
 
+        if "kpiBannerUrl" in data and data["kpiBannerUrl"]:
+            if not _validate_url(data["kpiBannerUrl"]):
+                errors.append("kpiBannerUrl must be a relative path or valid URL")
+
+        if "privacyUrl" in data and data["privacyUrl"]:
+            if not _validate_url(data["privacyUrl"]):
+                errors.append("privacyUrl must be a relative path or valid URL")
+
+        if "socialLinks" in data and not isinstance(data["socialLinks"], dict):
+            errors.append("socialLinks must be an object")
+
         if "features" in data and not isinstance(data["features"], dict):
             errors.append("features must be an object")
 
@@ -218,6 +328,8 @@ def admin_config(request: HttpRequest) -> JsonResponse:
         # Update fields if provided
         if "name" in data:
             db_config.name = _sanitize_string(data["name"], max_length=200) or db_config.name
+        if "brandName" in data:
+            db_config.brand_name = _sanitize_string(data["brandName"], max_length=200) or ""
         if "primaryColor" in data:
             db_config.primary_color = data["primaryColor"]
         if "secondaryColor" in data:
@@ -230,6 +342,12 @@ def admin_config(request: HttpRequest) -> JsonResponse:
             db_config.section_images = data["sectionImages"]
         if "sectionDescriptions" in data:
             db_config.section_descriptions = data["sectionDescriptions"]
+        if "kpiBannerUrl" in data:
+            db_config.kpi_banner_url = _sanitize_string(data["kpiBannerUrl"], max_length=2000) or ""
+        if "socialLinks" in data:
+            db_config.social_links = data["socialLinks"]
+        if "privacyUrl" in data:
+            db_config.privacy_url = _sanitize_string(data["privacyUrl"], max_length=2000) or ""
         if "features" in data:
             db_config.features = data["features"]
         if "departments" in data:
@@ -241,7 +359,7 @@ def admin_config(request: HttpRequest) -> JsonResponse:
 
         db_config.save()
 
-        logger.info(f"Updated tenant config: {tenant.tenant_id}")
+        logger.info(f"Updated tenant config: {tenant.tenant_id} by {email}")
 
         return JsonResponse({
             "success": True,

--- a/apps/tplanet-daemon/backend/portal/views/other_views.py
+++ b/apps/tplanet-daemon/backend/portal/views/other_views.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from portal.gmail import send_gmail
 from portal.manager import mockup_modify, mockup_fetch
 from portal.manager import news_post_create, news_post_list, news_post_get, news_post_delete
+from django_multi_tenant.views import _require_tenant_admin
 
 logger = logging.getLogger('tplanet')
 
@@ -22,7 +23,22 @@ def _response(**kwargs):
 
 @csrf_exempt
 def mockup_new(request):
-    """Create/modify mockup."""
+    """Create/modify mockup.
+
+    Auth: Bearer JWT required (tenant admin or YAML superuser). The email the
+    mockup is written under is ALWAYS derived from the authenticated user —
+    any client-supplied `email` POST field is ignored, so callers cannot
+    impersonate another hoster.
+    """
+    email, err = _require_tenant_admin(request)
+    if err:
+        return err
+
+    # Override any client-supplied email with JWT-derived one.
+    mutable_post = request.POST.copy()
+    mutable_post["email"] = email
+    request.POST = mutable_post
+
     result, description = mockup_modify(request)
     return _response(result=result, description=description)
 


### PR DESCRIPTION
Closes town-intelligent/tplanet-multi-tenant#64 (first slice — text fields + KPI banner upload)

## Summary

- Backend: `TenantConfig` model gets 4 new fields (`brand_name`, `kpi_banner_url`, `social_links`, `privacy_url`) via migration `0003`, `/api/tenant/admin-config` accepts them (GET + PUT), and **the endpoint is now auth-gated** — Bearer JWT, caller must be tenant `hosters[0]` or in YAML `superusers`. `/tenant/config` public response prefers DB over YAML for these fields (same pattern as `logo_url`).
- Frontend `admin_index`: TenantConfigSection gets a new 品牌/社群/隱私 subsection (brand name, privacy URL, facebook, youtube) plus a KPI banner widget with preview + upload. The upload reuses `/api/mockup/new` (`kpi-banner` field); the backend's stored URL (with real extension) is then written back into `kpiBannerUrl`, so the frontend never guesses `.png` vs `.jpg`.
- Nav.jsx / ProjectContent.jsx modifications present in the working tree are NOT part of this PR (left untouched — pre-existing local changes by another contributor).

## Scope deliberately NOT included

- District / region structured editors (JSON editor + map picker) — separate issue.
- Mockup-editor bottom half (banner-image / 4 section images / 4 descriptions) migration from FS to TenantConfig — separate issue.
- `sync_tenant_configs` command for bulk yaml→DB dump — left for merge-time operator task.

## Test plan (run after merge)

### Backend
- [ ] `docker exec mt-stable-backend python backend/manage.py migrate django_multi_tenant` succeeds
- [ ] `curl https://hackathon.4impact.cc/tenant/config | jq '.kpiBannerUrl'` still returns the yaml value (fallback works when DB is empty)
- [ ] PUT `/api/tenant/admin-config` without Authorization → 401
- [ ] PUT with a member's JWT (not hosters[0], not superuser) → 403
- [ ] PUT with admin JWT, body `{"brandName":"X"}` → 200, persisted to DB

### Frontend
- [ ] `/backend/admin_index` shows new 品牌/社群/隱私 subsection; fields populate from current config
- [ ] Changing a text field flips the "未儲存" badge
- [ ] Selecting a new KPI banner file shows preview immediately
- [ ] Save → `/api/mockup/new` called first (visible in Network tab), then `/api/tenant/admin-config` PUT
- [ ] Response URL reflects the real extension (`.jpg` if jpg was uploaded, `.png` if png)

### End-to-end
- [ ] hackathon.4impact.cc/kpi still shows the hackathon banner after admin uploads a new one
- [ ] sechome.cc/kpi falls back to bundled Secondhome@AI image (no `kpiBannerUrl` on default tenant)

## Notes for reviewer

- `apps/` directory is gitignored in this repo — tracked files need `-f`. New files in this PR (`0003_add_content_fields.py`, `models.py` overwrite) were force-added intentionally.
- `tenants.yml` is **not** in this PR (gitignored) — add `kpi_banner_url: "/static/new_mockup/ti@4impact.cc/kpi-banner.png"` to the hackathon tenant in the host copy if you want the yaml fallback to stay meaningful after admin CMS takes over.